### PR TITLE
Workaround for I2C sending zero byte data

### DIFF
--- a/modules/nrfx/drivers/src/nrfx_twim.c
+++ b/modules/nrfx/drivers/src/nrfx_twim.c
@@ -416,6 +416,11 @@ __STATIC_INLINE nrfx_err_t twim_xfer(twim_control_block_t        * p_cb,
         nrf_twim_task_trigger(p_twim, start_task);
     }
 
+    if (start_task == NRF_TWIM_TASK_STARTTX && p_xfer_desc->primary_length == 0)
+    {
+        nrf_twim_task_trigger(p_twim, NRF_TWIM_TASK_STOP);
+    }
+
     if (p_cb->handler)
     {
         if (flags & NRFX_TWIM_FLAG_NO_XFER_EVT_HANDLER)


### PR DESCRIPTION
### Problem
Nordic SDK don't support sending zero byte, if we send zero byte I2C clock will be pull down, and it won't generate any events.

### Solution
When sending zero byte, we send a `STOP` signal after sending `START` signal, the driver will generate `NRFX_TWIM_EVT_DONE` instead of generating no event.

### Step to test
1. Check out i2c branch https://github.com/particle-iot/firmware-private/pull/159
1. Refer to the instruction in that pull request

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
