### PR TITLE
Add user event SET_LINE_CODING to USB CDC driver

### DIFF
--- a/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c
+++ b/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.c
@@ -386,7 +386,13 @@ static ret_code_t setup_req_class_out(app_usbd_class_inst_t const * p_inst,
                 return NRF_ERROR_NOT_SUPPORTED;
             }
 
-            return cdc_acm_req_out_datastage(p_inst, p_setup_ev);
+            ret_code_t err_code = cdc_acm_req_out_datastage(p_inst, p_setup_ev);
+            if (err_code == NRF_SUCCESS) 
+            {
+                user_event_handler(p_inst, APP_USBD_CDC_ACM_USER_EVT_SET_LINE_CODING);
+            }
+            
+            return err_code;
         }
         case APP_USBD_CDC_REQ_SET_CONTROL_LINE_STATE:
         {

--- a/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.h
+++ b/components/libraries/usbd/class/cdc/acm/app_usbd_cdc_acm.h
@@ -108,6 +108,8 @@ typedef enum app_usbd_cdc_acm_user_event_e {
 
     APP_USBD_CDC_ACM_USER_EVT_PORT_OPEN,   /**< User event PORT_OPEN.  */
     APP_USBD_CDC_ACM_USER_EVT_PORT_CLOSE,  /**< User event PORT_CLOSE. */
+
+    APP_USBD_CDC_ACM_USER_EVT_SET_LINE_CODING
 } app_usbd_cdc_acm_user_event_t;
 
 /*lint -restore*/


### PR DESCRIPTION
USB CDC driver only generates `tx done`, `rx done` `com open`, `com close` events, we need `set line coding` event for `void USB_USART_LineCoding_BitRate_Handler(void (*handler)(uint32_t bitRate)) `.