### PR TITLE
Use the new method in SDK15.3 to detect chip version

### DIFF
--- a/components/drivers_nrf/usbd/nrf_drv_usbd_errata.h
+++ b/components/drivers_nrf/usbd/nrf_drv_usbd_errata.h
@@ -85,6 +85,11 @@ static inline bool nrf_drv_usbd_errata_type_52840_proto1(void)
                ( ((*(uint32_t *)0xF0000FEC) & 0xF0) == 0x00 ) );
 }
 
+static inline bool nrf_drv_usbd_errata_type_52840_eng_b(void)
+{
+    return (*(uint32_t *)0x10000130UL == 0x8UL) && (*(uint32_t *)0x10000134UL >= 0x1UL);
+}
+
 /**
  * @brief Internal auxiliary function to check if the program is running on first final product of
  *        NRF52840 chip
@@ -93,9 +98,7 @@ static inline bool nrf_drv_usbd_errata_type_52840_proto1(void)
  */
 static inline bool nrf_drv_usbd_errata_type_52840_fp1(void)
 {
-    return ( nrf_drv_usbd_errata_type_52840() &&
-               ( ((*(uint32_t *)0xF0000FE8) & 0xF0) == 0x20 ) &&
-               ( ((*(uint32_t *)0xF0000FEC) & 0xF0) == 0x00 ) );
+    return nrf_drv_usbd_errata_type_52840() && nrf_drv_usbd_errata_type_52840_eng_b();
 }
 
 /**


### PR DESCRIPTION
SDK15.0 doesn't support the detection for nRF52840-REV-2 which causes workaround for errata 187 failed, you'll find the USB gets stuck in waiting for the ready flag in the driver.

This fix is from SDK15.3, it is tested on:
Xenon Dev Board, nRF52840-REV-1
BoronDev Board, nRF52840-REV-1
BSoM, nRF52840-REV-2
