### PR TITLE
Fixing hardware timing issues for i2c

### DIFF
--- a/components/drivers_nrf/twi_master/deprecated/twi_sw_master.c
+++ b/components/drivers_nrf/twi_master/deprecated/twi_sw_master.c
@@ -383,7 +383,8 @@ static bool twi_master_clock_byte(uint_fast8_t databyte)
     // Pull SCL high and wait a moment for SDA line to settle
     // Make sure slave is not stretching the clock
     transfer_succeeded &= twi_master_wait_while_scl_low();
-
+    TWI_DELAY(); //hack to compensate hardware timing bug
+    
     // Read ACK/NACK. NACK == 1, ACK == 0
     transfer_succeeded &= !(TWI_SDA_READ());
 


### PR DESCRIPTION
I came across the same issue as described here: https://devzone.nordicsemi.com/f/nordic-q-a/48166/i2c-clock-stretching-on-nrf52840
This hack should prevent the first clock after a clock stretch to be too short. We initially started our investigation because of random bit shifts ( >> 1) in the communication with BQ40Z50 which resulted in faulty values. In case of fuel gauges and chargers this can lead to big problems (settings wrong currents, voltages, ...).

This is how a read byte should look like:
![BQ40Z50 success](https://user-images.githubusercontent.com/3322872/59158438-6421d600-8aba-11e9-84ae-0eca56cc040a.png)

This is how it sometimes actually looks:
![BQ40Z50 failed](https://user-images.githubusercontent.com/3322872/59158439-6421d600-8aba-11e9-93fb-732cf3093973.png)
