### PR TITLE
nrf spi to init with H0H1 drive strength

### DIFF
--- a/modules/nrfx/drivers/src/nrfx_spi.c
+++ b/modules/nrfx/drivers/src/nrfx_spi.c
@@ -138,7 +138,7 @@ nrfx_err_t nrfx_spi_init(nrfx_spi_t const * const  p_instance,
                  NRF_GPIO_PIN_DIR_OUTPUT,
                  NRF_GPIO_PIN_INPUT_CONNECT,
                  NRF_GPIO_PIN_NOPULL,
-                 NRF_GPIO_PIN_S0S1,
+                 NRF_GPIO_PIN_H0H1,
                  NRF_GPIO_PIN_NOSENSE);
     // - MOSI (optional) - output with initial value 0,
     if (p_config->mosi_pin != NRFX_SPI_PIN_NOT_USED)


### PR DESCRIPTION
### Problem

Currently the drive strength for SPI on Gen3 is set to STANDARD, that is causing issues when running multiple SPI devices (to run at default higher SPI bit rates).

### Solution

In addition to making the necessary changes on the device-os side, also making the default setting on NRF side so it doesn't over write it.

### References

[ch58614](https://app.clubhouse.io/particle/story/58614/gen-3-nrf52840-devices-have-gpio-set-to-standard-drive-but-may-be-more-stable-with-high-drive-enabled-by-default)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
