### PR TITLE
Update QSPI driver to SDK v 17.1.0_ddde560 for LFM functions

### DIFF
--- a/modules/nrfx/drivers/include/nrfx_qspi.h
+++ b/modules/nrfx/drivers/include/nrfx_qspi.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -55,21 +55,17 @@ extern "C" {
  * @brief   Quad Serial Peripheral Interface (QSPI) peripheral driver.
  */
 
-/**
- * @brief QSPI driver instance configuration structure.
- */
+/** @brief QSPI driver instance configuration structure. */
 typedef struct
 {
     uint32_t             xip_offset;   /**< Address offset into the external memory for Execute in Place operation. */
-    nrf_qspi_pins_t      pins;         /**< Pins configuration structure. */
+    nrf_qspi_pins_t      pins;         /**< Pin configuration structure. */
     nrf_qspi_prot_conf_t prot_if;      /**< Protocol layer interface configuration structure. */
     nrf_qspi_phy_conf_t  phy_if;       /**< Physical layer interface configuration structure. */
     uint8_t              irq_priority; /**< Interrupt priority. */
 } nrfx_qspi_config_t;
 
-/**
- * @brief QSPI instance default configuration.
- */
+/** @brief QSPI instance default configuration. */
 #define NRFX_QSPI_DEFAULT_CONFIG                                        \
 {                                                                       \
     .xip_offset  = NRFX_QSPI_CONFIG_XIP_OFFSET,                         \
@@ -81,7 +77,6 @@ typedef struct
        .io2_pin     = NRFX_QSPI_PIN_IO2,                                \
        .io3_pin     = NRFX_QSPI_PIN_IO3,                                \
     },                                                                  \
-    .irq_priority   = (uint8_t)NRFX_QSPI_CONFIG_IRQ_PRIORITY,           \
     .prot_if = {                                                        \
         .readoc     = (nrf_qspi_readoc_t)NRFX_QSPI_CONFIG_READOC,       \
         .writeoc    = (nrf_qspi_writeoc_t)NRFX_QSPI_CONFIG_WRITEOC,     \
@@ -89,16 +84,15 @@ typedef struct
         .dpmconfig  = false,                                            \
     },                                                                  \
     .phy_if = {                                                         \
-        .sck_freq   = (nrf_qspi_frequency_t)NRFX_QSPI_CONFIG_FREQUENCY, \
         .sck_delay  = (uint8_t)NRFX_QSPI_CONFIG_SCK_DELAY,              \
+        .dpmen      = false,                                            \
         .spi_mode   = (nrf_qspi_spi_mode_t)NRFX_QSPI_CONFIG_MODE,       \
-        .dpmen      = false                                             \
+        .sck_freq   = (nrf_qspi_frequency_t)NRFX_QSPI_CONFIG_FREQUENCY, \
     },                                                                  \
+    .irq_priority   = (uint8_t)NRFX_QSPI_CONFIG_IRQ_PRIORITY,           \
 }
 
-/**
- * @brief QSPI custom instruction helper with default configuration.
- */
+/** @brief QSPI custom instruction helper with the default configuration. */
 #define NRFX_QSPI_DEFAULT_CINSTR(opc, len) \
 {                                          \
     .opcode    = (opc),                    \
@@ -118,16 +112,14 @@ typedef enum
     NRFX_QSPI_EVENT_DONE, /**< Transfer done. */
 } nrfx_qspi_evt_t;
 
-/**
- * @brief QSPI driver event handler type.
- */
+/** @brief QSPI driver event handler type. */
 typedef void (*nrfx_qspi_handler_t)(nrfx_qspi_evt_t event, void * p_context);
 
 /**
  * @brief Function for initializing the QSPI driver instance.
  *
- * This function configures the peripheral and its interrupts and activates it. During the 
- * activation process, the internal clocks are started and the QSPI peripheral tries to read 
+ * This function configures the peripheral and its interrupts, and activates it. During the
+ * activation process, the internal clocks are started and the QSPI peripheral tries to read
  * the status byte to read the busy bit. Reading the status byte is done in a simple poll and wait
  * mechanism.
  * If the busy bit is 1, this indicates issues with the external memory device. As a result,
@@ -138,32 +130,30 @@ typedef void (*nrfx_qspi_handler_t)(nrfx_qspi_evt_t event, void * p_context);
  * - Make sure that the memory device does not perform other operations like erasing or writing.
  * - Check if there is a short circuit.
  *
- * @param[in] p_config   Pointer to the structure with initial configuration.
- * @param[in] handler    Event handler provided by the user. If NULL, transfers
- *                       will be performed in blocking mode.
- * @param[in] p_context  Pointer to context. Use in interrupt handler.
+ * @param[in] p_config  Pointer to the structure with the initial configuration.
+ * @param[in] handler   Event handler provided by the user. If NULL, transfers
+ *                      will be performed in blocking mode.
+ * @param[in] p_context Pointer to context. Use in the interrupt handler.
  *
- * @retval NRFX_SUCCESS             If initialization was successful.
- * @retval NRFX_ERROR_TIMEOUT       If the peripheral cannot connect with external memory.
- * @retval NRFX_ERROR_INVALID_STATE If the driver was already initialized.
- * @retval NRFX_ERROR_INVALID_PARAM If the pin configuration was incorrect.
+ * @retval NRFX_SUCCESS             Initialization was successful.
+ * @retval NRFX_ERROR_TIMEOUT       The peripheral cannot connect with external memory.
+ * @retval NRFX_ERROR_INVALID_STATE The driver was already initialized.
+ * @retval NRFX_ERROR_INVALID_PARAM The pin configuration was incorrect.
  */
 nrfx_err_t nrfx_qspi_init(nrfx_qspi_config_t const * p_config,
                           nrfx_qspi_handler_t        handler,
                           void *                     p_context);
 
-/**
- * @brief Function for uninitializing the QSPI driver instance.
- */
+/** @brief Function for uninitializing the QSPI driver instance. */
 void nrfx_qspi_uninit(void);
 
 /**
- * @brief Function for reading data from QSPI memory.
+ * @brief Function for reading data from the QSPI memory.
  *
  * Write, read, and erase operations check memory device busy state before starting the operation.
  * If the memory is busy, the resulting action depends on the mode in which the read operation is used:
- *  - blocking mode (without handler) - a delay occurs until the last operation still runs and
- *    until operation data is still being read.
+ *  - blocking mode (without handler) - a delay occurs until the last operation runs and
+ *    until the operation data is being read.
  *  - interrupt mode (with handler) - event emission occurs after the last operation
  *    and reading of data are finished.
  *
@@ -171,10 +161,11 @@ void nrfx_qspi_uninit(void);
  * @param[in]  rx_buffer_length Size of the data to read.
  * @param[in]  src_address      Address in memory to read from.
  *
- * @retval NRFX_SUCCESS            If the operation was successful (blocking mode) or operation
+ * @retval NRFX_SUCCESS            The operation was successful (blocking mode) or operation
  *                                 was commissioned (handler mode).
- * @retval NRFX_ERROR_BUSY         If the driver currently handles another operation.
- * @retval NRFX_ERROR_INVALID_ADDR If the provided buffer is not placed in the Data RAM region.
+ * @retval NRFX_ERROR_BUSY         The driver currently handles another operation.
+ * @retval NRFX_ERROR_INVALID_ADDR The provided buffer is not placed in the Data RAM region
+ *                                 or its address is not aligned to a 32-bit word.
  */
 nrfx_err_t nrfx_qspi_read(void *   p_rx_buffer,
                           size_t   rx_buffer_length,
@@ -185,8 +176,8 @@ nrfx_err_t nrfx_qspi_read(void *   p_rx_buffer,
  *
  * Write, read, and erase operations check memory device busy state before starting the operation.
  * If the memory is busy, the resulting action depends on the mode in which the write operation is used:
- *  - blocking mode (without handler) - a delay occurs until the last operation still runs and
- *    until operation data is still being sent.
+ *  - blocking mode (without handler) - a delay occurs until the last operation runs or
+ *    until the operation data is being sent.
  *  - interrupt mode (with handler) - event emission occurs after the last operation
  *    and sending of operation data are finished.
  * To manually control operation execution in the memory device, use @ref nrfx_qspi_mem_busy_check
@@ -198,10 +189,11 @@ nrfx_err_t nrfx_qspi_read(void *   p_rx_buffer,
  * @param[in] tx_buffer_length Size of the data to write.
  * @param[in] dst_address      Address in memory to write to.
  *
- * @retval NRFX_SUCCESS            If the operation was successful (blocking mode) or operation
+ * @retval NRFX_SUCCESS            The operation was successful (blocking mode) or operation
  *                                 was commissioned (handler mode).
- * @retval NRFX_ERROR_BUSY         If the driver currently handles other operation.
- * @retval NRFX_ERROR_INVALID_ADDR If the provided buffer is not placed in the Data RAM region.
+ * @retval NRFX_ERROR_BUSY         The driver currently handles other operation.
+ * @retval NRFX_ERROR_INVALID_ADDR The provided buffer is not placed in the Data RAM region
+ *                                 or its address is not aligned to a 32-bit word.
  */
 nrfx_err_t nrfx_qspi_write(void const * p_tx_buffer,
                            size_t       tx_buffer_length,
@@ -212,8 +204,8 @@ nrfx_err_t nrfx_qspi_write(void const * p_tx_buffer,
  *
  * Write, read, and erase operations check memory device busy state before starting the operation.
  * If the memory is busy, the resulting action depends on the mode in which the erase operation is used:
- *  - blocking mode (without handler) - a delay occurs until the last operation still runs and
- *    until operation data is still being sent.
+ *  - blocking mode (without handler) - a delay occurs until the last operation runs or
+ *    until the operation data is being sent.
  *  - interrupt mode (with handler) - event emission occurs after the last operation
  *    and sending of operation data are finished.
  * To manually control operation execution in the memory device, use @ref nrfx_qspi_mem_busy_check
@@ -225,9 +217,10 @@ nrfx_err_t nrfx_qspi_write(void const * p_tx_buffer,
  * @param[in] start_address Memory address to start erasing. If chip erase is performed, address
  *                          field is ommited.
  *
- * @retval NRFX_SUCCESS    If the operation was successful (blocking mode) or operation
- *                         was commissioned (handler mode).
- * @retval NRFX_ERROR_BUSY If the driver currently handles another operation.
+ * @retval NRFX_SUCCESS            The operation was successful (blocking mode) or operation
+ *                                 was commissioned (handler mode).
+ * @retval NRFX_ERROR_INVALID_ADDR The provided start address is not aligned to a 32-bit word.
+ * @retval NRFX_ERROR_BUSY         The driver currently handles another operation.
  */
 nrfx_err_t nrfx_qspi_erase(nrf_qspi_erase_len_t length,
                            uint32_t             start_address);
@@ -235,9 +228,9 @@ nrfx_err_t nrfx_qspi_erase(nrf_qspi_erase_len_t length,
 /**
  * @brief Function for starting an erase operation of the whole chip.
  *
- * @retval NRFX_SUCCESS    If the operation was successful (blocking mode) or operation
+ * @retval NRFX_SUCCESS    The operation was successful (blocking mode) or operation
  *                         was commissioned (handler mode).
- * @retval NRFX_ERROR_BUSY If the driver currently handles another operation.
+ * @retval NRFX_ERROR_BUSY The driver currently handles another operation.
  */
 nrfx_err_t nrfx_qspi_chip_erase(void);
 
@@ -245,8 +238,8 @@ nrfx_err_t nrfx_qspi_chip_erase(void);
  * @brief Function for getting the current driver status and status byte of memory device with
  *        testing WIP (write in progress) bit.
  *
- * @retval NRFX_SUCCESS    If the driver and memory are ready to handle a new operation.
- * @retval NRFX_ERROR_BUSY If the driver or memory currently handle another operation.
+ * @retval NRFX_SUCCESS    The driver and memory are ready to handle a new operation.
+ * @retval NRFX_ERROR_BUSY The driver or memory currently handle another operation.
  */
 nrfx_err_t nrfx_qspi_mem_busy_check(void);
 
@@ -261,13 +254,14 @@ nrfx_err_t nrfx_qspi_mem_busy_check(void);
  * @param[in]  p_tx_buffer Pointer to the array with data to send. Can be NULL if only opcode is transmitted.
  * @param[out] p_rx_buffer Pointer to the array for data to receive. Can be NULL if there is nothing to receive.
  *
- * @retval NRFX_SUCCESS            If the operation was successful.
- * @retval NRFX_ERROR_TIMEOUT      If the external memory is busy or there are connection issues.
- * @retval NRFX_ERROR_BUSY         If the driver currently handles other operation.
+ * @retval NRFX_SUCCESS       The operation was successful.
+ * @retval NRFX_ERROR_TIMEOUT The external memory is busy or there are connection issues.
+ * @retval NRFX_ERROR_BUSY    The driver currently handles other operation.
  */
 nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
                                  void const *                   p_tx_buffer,
                                  void *                         p_rx_buffer);
+
 /**
  * @brief Function for sending operation code and data to the memory device with simpler configuration.
  *
@@ -278,17 +272,56 @@ nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
  * @param[in] length      Length of the data to send and opcode. See @ref nrf_qspi_cinstr_len_t.
  * @param[in] p_tx_buffer Pointer to input data array.
  *
- * @retval NRFX_SUCCESS            If the operation was successful.
- * @retval NRFX_ERROR_BUSY         If the driver currently handles another operation.
+ * @retval NRFX_SUCCESS    The operation was successful.
+ * @retval NRFX_ERROR_BUSY The driver currently handles another operation.
  */
 nrfx_err_t nrfx_qspi_cinstr_quick_send(uint8_t               opcode,
                                        nrf_qspi_cinstr_len_t length,
                                        void const *          p_tx_buffer);
 
+/**
+ * @brief Function for starting the custom instruction long frame mode.
+ *
+ * The long frame mode is a mechanism that allows for arbitrary byte length custom instructions.
+ * Use this function to initiate a custom transaction by sending custom instruction opcode.
+ * To send and receive data, use @ref nrfx_qspi_lfm_xfer.
+ *
+ * @param[in] p_config Pointer to the structure with custom instruction opcode and transfer
+ *                     configuration. Transfer length must be set to @ref NRF_QSPI_CINSTR_LEN_1B.
+ *
+ * @retval NRFX_SUCCESS       Operation was successful.
+ * @retval NRFX_ERROR_BUSY    Driver currently handles other operation.
+ * @retval NRFX_ERROR_TIMEOUT External memory is busy or there are connection issues.
+ */
+nrfx_err_t nrfx_qspi_lfm_start(nrf_qspi_cinstr_conf_t const * p_config);
+
+/**
+ * @brief Function for sending and receiving data in the custom instruction long frame mode.
+ *
+ * Both specified buffers must be at least @p transfer_length bytes in size.
+ *
+ * @param[in]  p_tx_buffer     Pointer to the array with data to send.
+ *                             Can be NULL if there is nothing to send.
+ * @param[out] p_rx_buffer     Pointer to the array for receiving data.
+ *                             Can be NULL if there is nothing to receive.
+ * @param[in]  transfer_length Number of bytes to send and receive.
+ * @param[in]  finalize        True if custom instruction long frame mode is to be finalized
+ *                             after this transfer.
+ *
+ * @retval NRFX_SUCCESS       Operation was successful.
+ * @retval NRFX_ERROR_TIMEOUT External memory is busy or there are connection issues.
+ *                            Long frame mode becomes deactivated.
+ */
+nrfx_err_t nrfx_qspi_lfm_xfer(void const * p_tx_buffer,
+                              void *       p_rx_buffer,
+                              size_t       transfer_length,
+                              bool         finalize);
+
+/** @} */
+
 
 void nrfx_qspi_irq_handler(void);
 
-/** @} */
 
 #ifdef __cplusplus
 }

--- a/modules/nrfx/drivers/src/nrfx_qspi.c
+++ b/modules/nrfx/drivers/src/nrfx_qspi.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -43,39 +43,39 @@
 #if NRFX_CHECK(NRFX_QSPI_ENABLED)
 
 #include <nrfx_qspi.h>
+#include <hal/nrf_gpio.h>
 
-
-/**
- * @brief Command byte used to read status register.
- *
- */
+/** @brief Command byte used to read status register. */
 #define QSPI_STD_CMD_RDSR 0x05
 
-/**
- * @brief Byte used to mask status register and retrieve the write-in-progess bit.
- *
- */
+/** @brief Byte used to mask status register and retrieve the write-in-progess bit. */
 #define QSPI_MEM_STATUSREG_WIP_Pos 0x01
 
-/**
- * @brief Default time used in timeout function.
- */
+/** @brief Default time used in timeout function. */
 #define QSPI_DEF_WAIT_TIME_US 10
 
-/**
- * @brief Default number of tries in timeout function.
- */
+/** @brief Default number of tries in timeout function. */
 #define QSPI_DEF_WAIT_ATTEMPTS 100
 
 /**
-  * @brief Control block - driver instance local data.
-  */
+ * @brief Macro for initializing a QSPI pin.
+ *
+ * QSPI peripheral expects high drive pin strength.
+ */
+#define QSPI_PIN_INIT(_pin) nrf_gpio_cfg((_pin),                        \
+                                         NRF_GPIO_PIN_DIR_INPUT,        \
+                                         NRF_GPIO_PIN_INPUT_DISCONNECT, \
+                                         NRF_GPIO_PIN_NOPULL,           \
+                                         NRF_GPIO_PIN_H0H1,             \
+                                         NRF_GPIO_PIN_NOSENSE)
+
+/** @brief Control block - driver instance local data. */
 typedef struct
 {
-    nrfx_qspi_handler_t handler;          /**< Handler. */
-    nrfx_drv_state_t    state;            /**< Driver state. */
-    volatile bool       interrupt_driven; /**< Information if the current operation is performed and is interrupt-driven. */
-    void *              p_context;        /**< Driver context used in interrupt. */
+    nrfx_qspi_handler_t handler;   /**< Handler. */
+    nrfx_drv_state_t    state;     /**< Driver state. */
+    volatile bool       is_busy;   /**< Flag indicating that an operation is currently being performed. */
+    void *              p_context; /**< Driver context used in interrupt. */
 } qspi_control_block_t;
 
 static qspi_control_block_t m_cb;
@@ -83,7 +83,7 @@ static qspi_control_block_t m_cb;
 static nrfx_err_t qspi_task_perform(nrf_qspi_task_t task)
 {
     // Wait for peripheral
-    if (m_cb.interrupt_driven)
+    if (m_cb.is_busy)
     {
         return NRFX_ERROR_BUSY;
     }
@@ -92,7 +92,7 @@ static nrfx_err_t qspi_task_perform(nrf_qspi_task_t task)
 
     if (m_cb.handler)
     {
-        m_cb.interrupt_driven = true;
+        m_cb.is_busy = true;
         nrf_qspi_int_enable(NRF_QSPI, NRF_QSPI_INT_READY_MASK);
     }
 
@@ -117,9 +117,56 @@ static bool qspi_pins_configure(nrf_qspi_pins_t const * p_config)
         return false;
     }
 
+    QSPI_PIN_INIT(p_config->sck_pin);
+    QSPI_PIN_INIT(p_config->csn_pin);
+    QSPI_PIN_INIT(p_config->io0_pin);
+    QSPI_PIN_INIT(p_config->io1_pin);
+    if (p_config->io2_pin != NRF_QSPI_PIN_NOT_CONNECTED)
+    {
+        QSPI_PIN_INIT(p_config->io2_pin);
+    }
+    if (p_config->io3_pin != NRF_QSPI_PIN_NOT_CONNECTED)
+    {
+        QSPI_PIN_INIT(p_config->io3_pin);
+    }
+
     nrf_qspi_pins_set(NRF_QSPI, p_config);
 
     return true;
+}
+
+static void qspi_pins_deconfigure(void)
+{
+    nrf_qspi_pins_t pins;
+    nrf_qspi_pins_get(NRF_QSPI, &pins);
+
+    nrf_gpio_cfg_default(pins.sck_pin);
+    nrf_gpio_cfg_default(pins.csn_pin);
+    nrf_gpio_cfg_default(pins.io0_pin);
+    nrf_gpio_cfg_default(pins.io1_pin);
+    if (pins.io2_pin != NRF_QSPI_PIN_NOT_CONNECTED)
+    {
+        nrf_gpio_cfg_default(pins.io2_pin);
+    }
+    if (pins.io3_pin != NRF_QSPI_PIN_NOT_CONNECTED)
+    {
+        nrf_gpio_cfg_default(pins.io3_pin);
+    }
+}
+
+static nrfx_err_t qspi_ready_wait(void)
+{
+    bool result;
+    NRFX_WAIT_FOR(nrf_qspi_event_check(NRF_QSPI, NRF_QSPI_EVENT_READY),
+                                       QSPI_DEF_WAIT_ATTEMPTS,
+                                       QSPI_DEF_WAIT_TIME_US,
+                                       result);
+    if (!result)
+    {
+        return NRFX_ERROR_TIMEOUT;
+    }
+
+    return NRFX_SUCCESS;
 }
 
 nrfx_err_t nrfx_qspi_init(nrfx_qspi_config_t const * p_config,
@@ -141,7 +188,7 @@ nrfx_err_t nrfx_qspi_init(nrfx_qspi_config_t const * p_config,
     nrf_qspi_ifconfig0_set(NRF_QSPI, &p_config->prot_if);
     nrf_qspi_ifconfig1_set(NRF_QSPI, &p_config->phy_if);
 
-    m_cb.interrupt_driven = false;
+    m_cb.is_busy = false;
     m_cb.handler = handler;
     m_cb.p_context = p_context;
 
@@ -163,18 +210,8 @@ nrfx_err_t nrfx_qspi_init(nrfx_qspi_config_t const * p_config,
     nrf_qspi_task_trigger(NRF_QSPI, NRF_QSPI_TASK_ACTIVATE);
 
     // Waiting for the peripheral to activate
-    bool result;
-    NRFX_WAIT_FOR(nrf_qspi_event_check(NRF_QSPI, NRF_QSPI_EVENT_READY),
-                  QSPI_DEF_WAIT_ATTEMPTS,
-                  QSPI_DEF_WAIT_TIME_US,
-                  result);
 
-    if (!result)
-    {
-        return NRFX_ERROR_TIMEOUT;
-    }
-
-    return NRFX_SUCCESS;
+    return qspi_ready_wait();
 }
 
 nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
@@ -183,7 +220,7 @@ nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
 {
     NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
 
-    if (m_cb.interrupt_driven)
+    if (m_cb.is_busy)
     {
         return NRFX_ERROR_BUSY;
     }
@@ -196,17 +233,12 @@ nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
     {
         nrf_qspi_cinstrdata_set(NRF_QSPI, p_config->length, p_tx_buffer);
     }
+
     nrf_qspi_int_disable(NRF_QSPI, NRF_QSPI_INT_READY_MASK);
 
     nrf_qspi_cinstr_transfer_start(NRF_QSPI, p_config);
 
-    bool result;
-    NRFX_WAIT_FOR(nrf_qspi_event_check(NRF_QSPI, NRF_QSPI_EVENT_READY),
-                  QSPI_DEF_WAIT_ATTEMPTS,
-                  QSPI_DEF_WAIT_TIME_US,
-                  result);
-
-    if (!result)
+    if (qspi_ready_wait() == NRFX_ERROR_TIMEOUT)
     {
         // This timeout should never occur when WIPWAIT is not active, since in this
         // case the QSPI peripheral should send the command immediately, without any
@@ -216,7 +248,6 @@ nrfx_err_t nrfx_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const * p_config,
         return NRFX_ERROR_TIMEOUT;
     }
     nrf_qspi_event_clear(NRF_QSPI, NRF_QSPI_EVENT_READY);
-    nrf_qspi_int_enable(NRF_QSPI, NRF_QSPI_INT_READY_MASK);
 
     if (p_rx_buffer)
     {
@@ -232,6 +263,93 @@ nrfx_err_t nrfx_qspi_cinstr_quick_send(uint8_t               opcode,
 {
     nrf_qspi_cinstr_conf_t config = NRFX_QSPI_DEFAULT_CINSTR(opcode, length);
     return nrfx_qspi_cinstr_xfer(&config, p_tx_buffer, NULL);
+}
+
+nrfx_err_t nrfx_qspi_lfm_start(nrf_qspi_cinstr_conf_t const * p_config)
+{
+    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    NRFX_ASSERT(!(nrf_qspi_cinstr_long_transfer_is_ongoing(NRF_QSPI)));
+    NRFX_ASSERT(p_config->length == NRF_QSPI_CINSTR_LEN_1B);
+
+    if (m_cb.is_busy)
+    {
+        return NRFX_ERROR_BUSY;
+    }
+
+    nrf_qspi_cinstr_long_transfer_start(NRF_QSPI, p_config);
+
+    if (qspi_ready_wait() == NRFX_ERROR_TIMEOUT)
+    {
+        /* In case of error, abort long frame mode */
+        nrf_qspi_cinstr_long_transfer_continue(NRF_QSPI, NRF_QSPI_CINSTR_LEN_1B, true);
+        return NRFX_ERROR_TIMEOUT;
+    }
+
+    m_cb.is_busy = true;
+    return NRFX_SUCCESS;
+}
+
+nrfx_err_t nrfx_qspi_lfm_xfer(void const * p_tx_buffer,
+                              void *       p_rx_buffer,
+                              size_t       transfer_length,
+                              bool         finalize)
+{
+    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    NRFX_ASSERT(nrf_qspi_cinstr_long_transfer_is_ongoing(NRF_QSPI));
+
+    nrfx_err_t status = NRFX_SUCCESS;
+
+    /* Perform transfers in packets of 8 bytes. Last transfer may be shorter. */
+    nrf_qspi_cinstr_len_t length = NRF_QSPI_CINSTR_LEN_9B;
+    for (uint32_t curr_byte = 0; curr_byte < transfer_length; curr_byte += 8)
+    {
+        uint32_t remaining_bytes = transfer_length - curr_byte;
+        if (remaining_bytes < 8)
+        {
+            length = (nrf_qspi_cinstr_len_t)(remaining_bytes + 1);
+        }
+
+        if (p_tx_buffer)
+        {
+            nrf_qspi_cinstrdata_set(NRF_QSPI,
+                                    length,
+                                    &((uint8_t const *)p_tx_buffer)[curr_byte]);
+        }
+
+        nrf_qspi_event_clear(NRF_QSPI, NRF_QSPI_EVENT_READY);
+
+        if (remaining_bytes <= 8)
+        {
+            nrf_qspi_cinstr_long_transfer_continue(NRF_QSPI, length, finalize);
+        }
+        else
+        {
+            nrf_qspi_cinstr_long_transfer_continue(NRF_QSPI, length, false);
+        }
+
+        if (qspi_ready_wait() == NRFX_ERROR_TIMEOUT)
+        {
+            /* In case of error, abort long frame mode */
+            nrf_qspi_cinstr_long_transfer_continue(NRF_QSPI, NRF_QSPI_CINSTR_LEN_1B, true);
+            status = NRFX_ERROR_TIMEOUT;
+            break;
+        }
+
+        if (p_rx_buffer)
+        {
+            nrf_qspi_cinstrdata_get(NRF_QSPI,
+                                    length,
+                                    &((uint8_t *)p_rx_buffer)[curr_byte]);
+        }
+    }
+    nrf_qspi_event_clear(NRF_QSPI, NRF_QSPI_EVENT_READY);
+
+    if ((finalize) || (status == NRFX_ERROR_TIMEOUT))
+    {
+        m_cb.is_busy = false;
+    }
+
+    return status;
 }
 
 nrfx_err_t nrfx_qspi_mem_busy_check(void)
@@ -261,15 +379,22 @@ void nrfx_qspi_uninit(void)
 {
     NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
 
+    if (nrf_qspi_cinstr_long_transfer_is_ongoing(NRF_QSPI))
+    {
+        nrf_qspi_cinstr_long_transfer_continue(NRF_QSPI, NRF_QSPI_CINSTR_LEN_1B, true);
+    }
+
+    NRFX_IRQ_DISABLE(QSPI_IRQn);
+
     nrf_qspi_int_disable(NRF_QSPI, NRF_QSPI_INT_READY_MASK);
 
     nrf_qspi_task_trigger(NRF_QSPI, NRF_QSPI_TASK_DEACTIVATE);
 
     nrf_qspi_disable(NRF_QSPI);
 
-    NRFX_IRQ_DISABLE(QSPI_IRQn);
-
     nrf_qspi_event_clear(NRF_QSPI, NRF_QSPI_EVENT_READY);
+
+    qspi_pins_deconfigure();
 
     m_cb.state = NRFX_DRV_STATE_UNINITIALIZED;
 }
@@ -280,17 +405,14 @@ nrfx_err_t nrfx_qspi_write(void const * p_tx_buffer,
 {
     NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
     NRFX_ASSERT(p_tx_buffer != NULL);
-    NRFX_ASSERT(nrfx_is_in_ram(p_tx_buffer));
-    NRFX_ASSERT(nrfx_is_word_aligned(p_tx_buffer));
 
-    if (!nrfx_is_in_ram(p_tx_buffer))
+    if (!nrfx_is_in_ram(p_tx_buffer) || !nrfx_is_word_aligned(p_tx_buffer))
     {
         return NRFX_ERROR_INVALID_ADDR;
     }
 
     nrf_qspi_write_buffer_set(NRF_QSPI, p_tx_buffer, tx_buffer_length, dst_address);
     return qspi_task_perform(NRF_QSPI_TASK_WRITESTART);
-
 }
 
 nrfx_err_t nrfx_qspi_read(void *   p_rx_buffer,
@@ -299,10 +421,8 @@ nrfx_err_t nrfx_qspi_read(void *   p_rx_buffer,
 {
     NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
     NRFX_ASSERT(p_rx_buffer != NULL);
-    NRFX_ASSERT(nrfx_is_in_ram(p_rx_buffer));
-    NRFX_ASSERT(nrfx_is_word_aligned(p_rx_buffer));
 
-    if (!nrfx_is_in_ram(p_rx_buffer))
+    if (!nrfx_is_in_ram(p_rx_buffer) || !nrfx_is_word_aligned(p_rx_buffer))
     {
         return NRFX_ERROR_INVALID_ADDR;
     }
@@ -315,6 +435,12 @@ nrfx_err_t nrfx_qspi_erase(nrf_qspi_erase_len_t length,
                            uint32_t             start_address)
 {
     NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+
+    if (!nrfx_is_word_aligned((void const *)start_address))
+    {
+        return NRFX_ERROR_INVALID_ADDR;
+    }
+
     nrf_qspi_erase_ptr_set(NRF_QSPI, start_address, length);
     return qspi_task_perform(NRF_QSPI_TASK_ERASESTART);
 }
@@ -329,7 +455,7 @@ void nrfx_qspi_irq_handler(void)
     // Catch Event ready interrupts
     if (nrf_qspi_event_check(NRF_QSPI, NRF_QSPI_EVENT_READY))
     {
-        m_cb.interrupt_driven = false;
+        m_cb.is_busy = false;
         nrf_qspi_event_clear(NRF_QSPI, NRF_QSPI_EVENT_READY);
         m_cb.handler(NRFX_QSPI_EVENT_DONE, m_cb.p_context);
     }

--- a/modules/nrfx/hal/nrf_qspi.h
+++ b/modules/nrfx/hal/nrf_qspi.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ * Copyright (c) 2016 - 2021, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -61,47 +61,33 @@ extern "C" {
  */
 #define NRF_QSPI_PIN_NOT_CONNECTED 0xFF
 
-/**
- * @brief Macro for setting proper values to pin registers.
- */
-
+/** @brief Macro for setting proper values to pin registers. */
 #define NRF_QSPI_PIN_VAL(pin) (pin) == NRF_QSPI_PIN_NOT_CONNECTED ? 0xFFFFFFFF : (pin)
 
-/**
- * @brief QSPI tasks.
- */
+
+/** @brief QSPI tasks. */
 typedef enum
 {
-    /*lint -save -e30*/
     NRF_QSPI_TASK_ACTIVATE   = offsetof(NRF_QSPI_Type, TASKS_ACTIVATE),   /**< Activate the QSPI interface. */
     NRF_QSPI_TASK_READSTART  = offsetof(NRF_QSPI_Type, TASKS_READSTART),  /**< Start transfer from external flash memory to internal RAM. */
     NRF_QSPI_TASK_WRITESTART = offsetof(NRF_QSPI_Type, TASKS_WRITESTART), /**< Start transfer from internal RAM to external flash memory. */
     NRF_QSPI_TASK_ERASESTART = offsetof(NRF_QSPI_Type, TASKS_ERASESTART), /**< Start external flash memory erase operation. */
     NRF_QSPI_TASK_DEACTIVATE = offsetof(NRF_QSPI_Type, TASKS_DEACTIVATE), /**< Deactivate the QSPI interface. */
-    /*lint -restore*/
 } nrf_qspi_task_t;
 
-/**
- * @brief QSPI events.
- */
+/** @brief QSPI events. */
 typedef enum
 {
-    /*lint -save -e30*/
     NRF_QSPI_EVENT_READY = offsetof(NRF_QSPI_Type, EVENTS_READY) /**< QSPI peripheral is ready after it executes any task. */
-    /*lint -restore*/
 } nrf_qspi_event_t;
 
-/**
- * @brief QSPI interrupts.
- */
+/** @brief QSPI interrupts. */
 typedef enum
 {
     NRF_QSPI_INT_READY_MASK = QSPI_INTENSET_READY_Msk /**< Interrupt on READY event. */
 } nrf_qspi_int_mask_t;
 
-/**
- * @brief QSPI frequency divider values.
- */
+/** @brief QSPI frequency divider values. */
 typedef enum
 {
     NRF_QSPI_FREQ_32MDIV1,  /**< 32.0 MHz. */
@@ -122,9 +108,7 @@ typedef enum
     NRF_QSPI_FREQ_32MDIV16, /**< 2.00 MHz. */
 } nrf_qspi_frequency_t;
 
-/**
- * @brief Interface configuration for a read operation.
- */
+/** @brief Interface configuration for a read operation. */
 typedef enum
 {
     NRF_QSPI_READOC_FASTREAD = QSPI_IFCONFIG0_READOC_FASTREAD, /**< Single data line SPI. FAST_READ (opcode 0x0B). */
@@ -134,9 +118,7 @@ typedef enum
     NRF_QSPI_READOC_READ4IO  = QSPI_IFCONFIG0_READOC_READ4IO   /**< Quad data line SPI. READ4IO (opcode 0xEB). */
 } nrf_qspi_readoc_t;
 
-/**
- * @brief Interface configuration for a write operation.
- */
+/** @brief Interface configuration for a write operation. */
 typedef enum
 {
     NRF_QSPI_WRITEOC_PP    = QSPI_IFCONFIG0_WRITEOC_PP,    /**< Single data line SPI. PP (opcode 0x02). */
@@ -145,27 +127,21 @@ typedef enum
     NRF_QSPI_WRITEOC_PP4IO = QSPI_IFCONFIG0_WRITEOC_PP4IO, /**< Quad data line SPI. READ4O (opcode 0x38). */
 } nrf_qspi_writeoc_t;
 
-/**
- * @brief Interface configuration for addressing mode.
- */
+/** @brief Interface configuration for addressing mode. */
 typedef enum
 {
     NRF_QSPI_ADDRMODE_24BIT = QSPI_IFCONFIG0_ADDRMODE_24BIT, /**< 24-bit addressing. */
     NRF_QSPI_ADDRMODE_32BIT = QSPI_IFCONFIG0_ADDRMODE_32BIT  /**< 32-bit addressing. */
 } nrf_qspi_addrmode_t;
 
-/**
- * @brief QSPI SPI mode. Polarization and phase configuration.
- */
+/** @brief QSPI SPI mode. Polarization and phase configuration. */
 typedef enum
 {
     NRF_QSPI_MODE_0 = QSPI_IFCONFIG1_SPIMODE_MODE0, /**< Mode 0 (CPOL=0, CPHA=0). */
     NRF_QSPI_MODE_1 = QSPI_IFCONFIG1_SPIMODE_MODE3  /**< Mode 1 (CPOL=1, CPHA=1). */
 } nrf_qspi_spi_mode_t;
 
-/**
- * @brief Addressing configuration mode.
- */
+/** @brief Addressing configuration mode. */
 typedef enum
 {
     NRF_QSPI_ADDRCONF_MODE_NOINSTR = QSPI_ADDRCONF_MODE_NoInstr, /**< Do not send any instruction. */
@@ -174,9 +150,7 @@ typedef enum
     NRF_QSPI_ADDRCONF_MODE_ALL     = QSPI_ADDRCONF_MODE_All      /**< Send opcode, byte0, byte1. */
 } nrf_qspi_addrconfig_mode_t;
 
-/**
- * @brief Erasing data length.
- */
+/** @brief Erasing data length. */
 typedef enum
 {
     NRF_QSPI_ERASE_LEN_4KB  = QSPI_ERASE_LEN_LEN_4KB,  /**< Erase 4 kB block (flash command 0x20). */
@@ -184,9 +158,7 @@ typedef enum
     NRF_QSPI_ERASE_LEN_ALL  = QSPI_ERASE_LEN_LEN_All   /**< Erase all (flash command 0xC7). */
 } nrf_qspi_erase_len_t;
 
-/**
- * @brief Custom instruction length.
- */
+/** @brief Custom instruction length. */
 typedef enum
 {
     NRF_QSPI_CINSTR_LEN_1B = QSPI_CINSTRCONF_LENGTH_1B, /**< Send opcode only. */
@@ -200,9 +172,7 @@ typedef enum
     NRF_QSPI_CINSTR_LEN_9B = QSPI_CINSTRCONF_LENGTH_9B  /**< Send opcode, CINSTRDAT0.BYTE0 -> CINSTRDAT1.BYTE7. */
 } nrf_qspi_cinstr_len_t;
 
-/**
- * @brief Pins configuration.
- */
+/** @brief Pin configuration. */
 typedef struct
 {
     uint8_t sck_pin; /**< SCK pin number. */
@@ -217,9 +187,7 @@ typedef struct
                       */
 } nrf_qspi_pins_t;
 
-/**
- * @brief Custom instruction configuration.
- */
+/** @brief Custom instruction configuration. */
 typedef struct
 {
     uint8_t               opcode;    /**< Opcode used in custom instruction transmission. */
@@ -230,22 +198,18 @@ typedef struct
     bool                  wren;      /**< Send write enable before instruction. */
 } nrf_qspi_cinstr_conf_t;
 
-/**
- * @brief Addressing mode register configuration. See @ref nrf_qspi_addrconfig_set
- */
+/** @brief Addressing mode register configuration. See @ref nrf_qspi_addrconfig_set */
 typedef struct
 {
-    uint8_t                    opcode;  /**< Opcode used to enter proper addressing mode. */
+    uint8_t                    opcode;  /**< Opcode used to enter the proper addressing mode. */
     uint8_t                    byte0;   /**< Byte following the opcode. */
     uint8_t                    byte1;   /**< Byte following byte0. */
     nrf_qspi_addrconfig_mode_t mode;    /**< Extended addresing mode. */
-    bool                       wipwait; /**< Enable/disable waiting for complete operation execution. */
+    bool                       wipwait; /**< Enable or disable waiting for complete operation execution. */
     bool                       wren;    /**< Send write enable before instruction. */
 } nrf_qspi_addrconfig_conf_t;
 
-/**
- * @brief Structure with QSPI protocol interface configuration.
- */
+/** @brief Structure with QSPI protocol interface configuration. */
 typedef struct
 {
     nrf_qspi_readoc_t   readoc;    /**< Read operation code. */
@@ -254,9 +218,7 @@ typedef struct
     bool                dpmconfig; /**< Enable the Deep Power-down Mode (DPM) feature. */
 } nrf_qspi_prot_conf_t;
 
-/**
- * @brief QSPI physical interface configuration.
- */
+/** @brief QSPI physical interface configuration. */
 typedef struct
 {
     uint8_t              sck_delay; /**< tSHSL, tWHSL, and tSHWL in number of 16 MHz periods (62.5ns). */
@@ -265,19 +227,20 @@ typedef struct
     nrf_qspi_frequency_t sck_freq;  /**< SCK frequency given as enum @ref nrf_qspi_frequency_t. */
 } nrf_qspi_phy_conf_t;
 
+
 /**
- * @brief Function for activating a specific QSPI task.
+ * @brief Function for activating the specified QSPI task.
  *
- * @param[in] p_reg Pointer to the peripheral register structure.
- * @param[in] task  Task to activate.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  Task to be activated.
  */
 __STATIC_INLINE void nrf_qspi_task_trigger(NRF_QSPI_Type * p_reg, nrf_qspi_task_t task);
 
 /**
- * @brief Function for getting the address of a specific QSPI task register.
+ * @brief Function for getting the address of the specified QSPI task register.
  *
- * @param[in] p_reg Pointer to the peripheral register structure.
- * @param[in] task  Requested task.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] task  QSPI task.
  *
  * @return Address of the specified task register.
  */
@@ -285,59 +248,59 @@ __STATIC_INLINE uint32_t nrf_qspi_task_address_get(NRF_QSPI_Type const * p_reg,
                                                    nrf_qspi_task_t       task);
 
 /**
- * @brief Function for clearing a specific QSPI event.
+ * @brief Function for clearing the specified QSPI event.
  *
- * @param[in] p_reg      Pointer to the peripheral register structure.
- * @param[in] qspi_event Event to clear.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] event Event to be cleared.
  */
-__STATIC_INLINE void nrf_qspi_event_clear(NRF_QSPI_Type *  p_reg, nrf_qspi_event_t qspi_event);
+__STATIC_INLINE void nrf_qspi_event_clear(NRF_QSPI_Type * p_reg, nrf_qspi_event_t event);
 
 /**
- * @brief Function for checking the state of a specific SPI event.
+ * @brief Function for retrieving the state of the QSPI event.
  *
- * @param[in] p_reg      Pointer to the peripheral register structure.
- * @param[in] qspi_event Event to check.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] event Event to be checked.
  *
- * @retval true  If the event is set.
- * @retval false If the event is not set.
+ * @retval true  The event has been generated.
+ * @retval false The event has not been generated.
  */
-__STATIC_INLINE bool nrf_qspi_event_check(NRF_QSPI_Type const * p_reg, nrf_qspi_event_t qspi_event);
+__STATIC_INLINE bool nrf_qspi_event_check(NRF_QSPI_Type const * p_reg, nrf_qspi_event_t event);
 
 /**
- * @brief Function for getting the address of a specific QSPI event register.
+ * @brief Function for getting the address of the specified QSPI event register.
  *
- * @param[in] p_reg      Pointer to the peripheral register structure.
- * @param[in] qspi_event Requested event.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] event The specified event.
  *
  * @return Address of the specified event register.
  */
 __STATIC_INLINE uint32_t * nrf_qspi_event_address_get(NRF_QSPI_Type const * p_reg,
-                                                      nrf_qspi_event_t      qspi_event);
+                                                      nrf_qspi_event_t      event);
 
 /**
  * @brief Function for enabling specified interrupts.
  *
- * @param[in] p_reg          Pointer to the peripheral register structure.
- * @param[in] qspi_int_mask  Interrupts to enable.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be enabled.
  */
-__STATIC_INLINE void nrf_qspi_int_enable(NRF_QSPI_Type * p_reg, uint32_t qspi_int_mask);
+__STATIC_INLINE void nrf_qspi_int_enable(NRF_QSPI_Type * p_reg, uint32_t mask);
 
 /**
  * @brief Function for disabling specified interrupts.
  *
- * @param[in] p_reg          Pointer to the peripheral register structure.
- * @param[in] qspi_int_mask  Interrupts to disable.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ * @param[in] mask  Mask of interrupts to be disabled.
  */
-__STATIC_INLINE void nrf_qspi_int_disable(NRF_QSPI_Type * p_reg, uint32_t qspi_int_mask);
+__STATIC_INLINE void nrf_qspi_int_disable(NRF_QSPI_Type * p_reg, uint32_t mask);
 
 /**
  * @brief Function for retrieving the state of a given interrupt.
  *
- * @param[in] p_reg    Pointer to the peripheral register structure.
- * @param[in] qspi_int Interrupt to check.
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] qspi_int Interrupt to be checked.
  *
- * @retval true  If the interrupt is enabled.
- * @retval false If the interrupt is not enabled.
+ * @retval true  The interrupt is enabled.
+ * @retval false The interrupt is not enabled.
  */
 __STATIC_INLINE bool nrf_qspi_int_enable_check(NRF_QSPI_Type const * p_reg,
                                                nrf_qspi_int_mask_t   qspi_int);
@@ -345,14 +308,14 @@ __STATIC_INLINE bool nrf_qspi_int_enable_check(NRF_QSPI_Type const * p_reg,
 /**
  * @brief Function for enabling the QSPI peripheral.
  *
- * @param[in] p_reg Pointer to the peripheral register structure.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
 __STATIC_INLINE void nrf_qspi_enable(NRF_QSPI_Type * p_reg);
 
 /**
  * @brief Function for disabling the QSPI peripheral.
  *
- * @param[in] p_reg Pointer to the peripheral register structure.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  */
 __STATIC_INLINE void nrf_qspi_disable(NRF_QSPI_Type * p_reg);
 
@@ -362,16 +325,25 @@ __STATIC_INLINE void nrf_qspi_disable(NRF_QSPI_Type * p_reg);
  * If a given signal is not needed, pass the @ref NRF_QSPI_PIN_NOT_CONNECTED
  * value instead of its pin number.
  *
- * @param[in] p_reg  Pointer to the peripheral register structure.
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
  * @param[in] p_pins Pointer to the pins configuration structure. See @ref nrf_qspi_pins_t.
  */
 __STATIC_INLINE void nrf_qspi_pins_set(NRF_QSPI_Type *         p_reg,
                                        const nrf_qspi_pins_t * p_pins);
 
 /**
+ * @brief Function for getting the currently configured QSPI pins.
+ *
+ * @param[in]  p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[out] p_pins Pointer to the pins configuration structure to be filled with QSPI pins.
+ */
+__STATIC_INLINE void nrf_qspi_pins_get(NRF_QSPI_Type const * p_reg,
+                                       nrf_qspi_pins_t *     p_pins);
+
+/**
  * @brief Function for setting the QSPI XIPOFFSET register.
  *
- * @param[in] p_reg      Pointer to the peripheral register structure.
+ * @param[in] p_reg      Pointer to the structure of registers of the peripheral.
  * @param[in] xip_offset Address offset in the external memory for Execute in Place operation.
  */
 __STATIC_INLINE void nrf_qspi_xip_offset_set(NRF_QSPI_Type * p_reg,
@@ -380,8 +352,9 @@ __STATIC_INLINE void nrf_qspi_xip_offset_set(NRF_QSPI_Type * p_reg,
 /**
  * @brief Function for setting the QSPI IFCONFIG0 register.
  *
- * @param[in] p_reg    Pointer to the peripheral register structure.
- * @param[in] p_config Pointer to the QSPI protocol interface configuration structure. See @ref nrf_qspi_prot_conf_t.
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the QSPI protocol interface configuration structure.
+ *                     See @ref nrf_qspi_prot_conf_t.
  */
 __STATIC_INLINE void nrf_qspi_ifconfig0_set(NRF_QSPI_Type *              p_reg,
                                             const nrf_qspi_prot_conf_t * p_config);
@@ -389,8 +362,9 @@ __STATIC_INLINE void nrf_qspi_ifconfig0_set(NRF_QSPI_Type *              p_reg,
 /**
  * @brief Function for setting the QSPI IFCONFIG1 register.
  *
- * @param[in] p_reg    Pointer to the peripheral register structure.
- * @param[in] p_config Pointer to the QSPI physical interface configuration structure. See @ref nrf_qspi_phy_conf_t.
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the QSPI physical interface configuration structure.
+ *                     See @ref nrf_qspi_phy_conf_t.
  */
 __STATIC_INLINE void nrf_qspi_ifconfig1_set(NRF_QSPI_Type *             p_reg,
                                             const nrf_qspi_phy_conf_t * p_config);
@@ -398,7 +372,7 @@ __STATIC_INLINE void nrf_qspi_ifconfig1_set(NRF_QSPI_Type *             p_reg,
 /**
  * @brief Function for setting the QSPI ADDRCONF register.
  *
- * Function must be executed before sending task NRF_QSPI_TASK_ACTIVATE. Data stored in the structure
+ * This function must be executed before sending task NRF_QSPI_TASK_ACTIVATE. Data stored in the structure
  * is sent during the start of the peripheral. Remember that the reset instruction can set
  * addressing mode to default in the memory device. If memory reset is necessary before configuring
  * the addressing mode, use custom instruction feature instead of this function.
@@ -406,8 +380,9 @@ __STATIC_INLINE void nrf_qspi_ifconfig1_set(NRF_QSPI_Type *             p_reg,
  * using a custom instruction feature (reset enable and then reset), set proper addressing mode
  * using the custom instruction feature.
  *
- * @param[in] p_reg    Pointer to the peripheral register structure.
- * @param[in] p_config Pointer to the addressing mode configuration structure. See @ref nrf_qspi_addrconfig_conf_t.
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the addressing mode configuration structure.
+ *                     See @ref nrf_qspi_addrconfig_conf_t.
 */
 __STATIC_INLINE void nrf_qspi_addrconfig_set(NRF_QSPI_Type *                    p_reg,
                                              const nrf_qspi_addrconfig_conf_t * p_config);
@@ -415,7 +390,7 @@ __STATIC_INLINE void nrf_qspi_addrconfig_set(NRF_QSPI_Type *                    
 /**
  * @brief Function for setting write data into the peripheral register (without starting the process).
  *
- * @param[in] p_reg     Pointer to the peripheral register structure.
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
  * @param[in] p_buffer  Pointer to the writing buffer.
  * @param[in] length    Lenght of the writing data.
  * @param[in] dest_addr Address in memory to write to.
@@ -428,7 +403,7 @@ __STATIC_INLINE void nrf_qspi_write_buffer_set(NRF_QSPI_Type * p_reg,
 /**
  * @brief Function for setting read data into the peripheral register (without starting the process).
  *
- * @param[in]  p_reg    Pointer to the peripheral register structure.
+ * @param[in]  p_reg    Pointer to the structure of registers of the peripheral.
  * @param[out] p_buffer Pointer to the reading buffer.
  * @param[in]  length   Length of the read data.
  * @param[in]  src_addr Address in memory to read from.
@@ -441,7 +416,7 @@ __STATIC_INLINE void nrf_qspi_read_buffer_set(NRF_QSPI_Type * p_reg,
 /**
  * @brief Function for setting erase data into the peripheral register (without starting the process).
  *
- * @param[in] p_reg      Pointer to the peripheral register structure.
+ * @param[in] p_reg      Pointer to the structure of registers of the peripheral.
  * @param[in] erase_addr Start address to erase. Address must have padding set to 4 bytes.
  * @param[in] len        Size of erasing area.
  */
@@ -452,7 +427,7 @@ __STATIC_INLINE void nrf_qspi_erase_ptr_set(NRF_QSPI_Type *      p_reg,
 /**
  * @brief Function for getting the peripheral status register.
  *
- * @param[in] p_reg Pointer to the peripheral register structure.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  *
  * @return Peripheral status register.
  */
@@ -461,7 +436,7 @@ __STATIC_INLINE uint32_t nrf_qspi_status_reg_get(NRF_QSPI_Type const * p_reg);
 /**
  * @brief Function for getting the device status register stored in the peripheral status register.
  *
- * @param[in] p_reg Pointer to the peripheral register structure.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  *
  * @return Device status register (lower byte).
  */
@@ -470,10 +445,10 @@ __STATIC_INLINE uint8_t nrf_qspi_sreg_get(NRF_QSPI_Type const * p_reg);
 /**
  * @brief Function for checking if the peripheral is busy or not.
  *
- * @param[in] p_reg Pointer to the peripheral register structure.
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
  *
- * @retval true  If QSPI is busy.
- * @retval false If QSPI is ready.
+ * @retval true  The QSPI is busy.
+ * @retval false The QSPI is ready.
  */
 __STATIC_INLINE bool nrf_qspi_busy_check(NRF_QSPI_Type const * p_reg);
 
@@ -483,7 +458,7 @@ __STATIC_INLINE bool nrf_qspi_busy_check(NRF_QSPI_Type const * p_reg);
  * This function can be ommited when using NRF_QSPI_CINSTR_LEN_1B as the length argument
  * (sending only opcode without data).
  *
- * @param[in] p_reg     Pointer to the peripheral register structure.
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
  * @param[in] length    Length of the custom instruction data.
  * @param[in] p_tx_data Pointer to the data to send with the custom instruction.
  */
@@ -493,7 +468,8 @@ __STATIC_INLINE void nrf_qspi_cinstrdata_set(NRF_QSPI_Type *       p_reg,
 
 /**
  * @brief Function for getting data from register after custom instruction transmission.
- * @param[in] p_reg     Pointer to the peripheral register structure.
+ *
+ * @param[in] p_reg     Pointer to the structure of registers of the peripheral.
  * @param[in] length    Length of the custom instruction data.
  * @param[in] p_rx_data Pointer to the reading buffer.
  */
@@ -504,12 +480,45 @@ __STATIC_INLINE void nrf_qspi_cinstrdata_get(NRF_QSPI_Type const * p_reg,
 /**
  * @brief Function for sending custom instruction to external memory.
  *
- * @param[in] p_reg    Pointer to the peripheral register structure.
- * @param[in] p_config Pointer to the custom instruction configuration structure. See @ref nrf_qspi_cinstr_conf_t.
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the custom instruction configuration structure.
+ *                     See @ref nrf_qspi_cinstr_conf_t.
  */
 
 __STATIC_INLINE void nrf_qspi_cinstr_transfer_start(NRF_QSPI_Type *                p_reg,
                                                     const nrf_qspi_cinstr_conf_t * p_config);
+
+/**
+ * @brief Function for starting a custom instruction long transfer.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] p_config Pointer to the custom instruction configuration structure.
+ *                     See @ref nrf_qspi_cinstr_conf_t.
+ */
+__STATIC_INLINE void nrf_qspi_cinstr_long_transfer_start(NRF_QSPI_Type *                p_reg,
+                                                         const nrf_qspi_cinstr_conf_t * p_config);
+
+/**
+ * @brief Function for checking whether a custom instruction long transfer is ongoing.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ *
+ * @retval true  Custom instruction long transfer is ongoing.
+ * @retval false Custom instruction long transfer is not ongoing.
+ */
+__STATIC_INLINE bool nrf_qspi_cinstr_long_transfer_is_ongoing(NRF_QSPI_Type const * p_reg);
+
+/**
+ * @brief Function for continuing a custom instruction long transfer.
+ *
+ * @param[in] p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[in] length   Length of the custom instruction data.
+ * @param[in] finalize True if the custom instruction long transfer is to be finalized.
+ *                     False if the custom instruction long transfer is to be continued.
+ */
+__STATIC_INLINE void nrf_qspi_cinstr_long_transfer_continue(NRF_QSPI_Type *       p_reg,
+                                                            nrf_qspi_cinstr_len_t length,
+                                                            bool                  finalize);
 
 #ifndef SUPPRESS_INLINE_IMPLEMENTATION
 
@@ -524,30 +533,30 @@ __STATIC_INLINE uint32_t nrf_qspi_task_address_get(NRF_QSPI_Type const * p_reg,
     return ((uint32_t)p_reg + (uint32_t)task);
 }
 
-__STATIC_INLINE void nrf_qspi_event_clear(NRF_QSPI_Type * p_reg, nrf_qspi_event_t qspi_event)
+__STATIC_INLINE void nrf_qspi_event_clear(NRF_QSPI_Type * p_reg, nrf_qspi_event_t event)
 {
-    *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)qspi_event)) = 0x0UL;
+    *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event)) = 0x0UL;
 }
 
-__STATIC_INLINE bool nrf_qspi_event_check(NRF_QSPI_Type const * p_reg, nrf_qspi_event_t qspi_event)
+__STATIC_INLINE bool nrf_qspi_event_check(NRF_QSPI_Type const * p_reg, nrf_qspi_event_t event)
 {
-    return (bool)*(volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)qspi_event);
+    return (bool)*(volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event);
 }
 
 __STATIC_INLINE uint32_t * nrf_qspi_event_address_get(NRF_QSPI_Type const * p_reg,
-                                                      nrf_qspi_event_t      qspi_event)
+                                                      nrf_qspi_event_t      event)
 {
-    return (uint32_t *)((uint8_t *)p_reg + (uint32_t)qspi_event);
+    return (uint32_t *)((uint8_t *)p_reg + (uint32_t)event);
 }
 
-__STATIC_INLINE void nrf_qspi_int_enable(NRF_QSPI_Type * p_reg, uint32_t qspi_int_mask)
+__STATIC_INLINE void nrf_qspi_int_enable(NRF_QSPI_Type * p_reg, uint32_t mask)
 {
-    p_reg->INTENSET = qspi_int_mask;
+    p_reg->INTENSET = mask;
 }
 
-__STATIC_INLINE void nrf_qspi_int_disable(NRF_QSPI_Type * p_reg, uint32_t qspi_int_mask)
+__STATIC_INLINE void nrf_qspi_int_disable(NRF_QSPI_Type * p_reg, uint32_t mask)
 {
-    p_reg->INTENCLR = qspi_int_mask;
+    p_reg->INTENCLR = mask;
 }
 
 __STATIC_INLINE bool nrf_qspi_int_enable_check(NRF_QSPI_Type const * p_reg,
@@ -577,6 +586,17 @@ __STATIC_INLINE void nrf_qspi_pins_set(NRF_QSPI_Type * p_reg, const nrf_qspi_pin
     p_reg->PSEL.IO1 = NRF_QSPI_PIN_VAL(p_pins->io1_pin);
     p_reg->PSEL.IO2 = NRF_QSPI_PIN_VAL(p_pins->io2_pin);
     p_reg->PSEL.IO3 = NRF_QSPI_PIN_VAL(p_pins->io3_pin);
+}
+
+__STATIC_INLINE void nrf_qspi_pins_get(NRF_QSPI_Type const * p_reg,
+                                       nrf_qspi_pins_t *     p_pins)
+{
+    p_pins->sck_pin = (uint8_t)p_reg->PSEL.SCK;
+    p_pins->csn_pin = (uint8_t)p_reg->PSEL.CSN;
+    p_pins->io0_pin = (uint8_t)p_reg->PSEL.IO0;
+    p_pins->io1_pin = (uint8_t)p_reg->PSEL.IO1;
+    p_pins->io2_pin = (uint8_t)p_reg->PSEL.IO2;
+    p_pins->io3_pin = (uint8_t)p_reg->PSEL.IO3;
 }
 
 __STATIC_INLINE void nrf_qspi_xip_offset_set(NRF_QSPI_Type * p_reg,
@@ -762,6 +782,34 @@ __STATIC_INLINE void nrf_qspi_cinstr_transfer_start(NRF_QSPI_Type *             
                          ((uint32_t)p_config->io3_level << QSPI_CINSTRCONF_LIO3_Pos) |
                          ((uint32_t)p_config->wipwait   << QSPI_CINSTRCONF_WIPWAIT_Pos) |
                          ((uint32_t)p_config->wren      << QSPI_CINSTRCONF_WREN_Pos));
+}
+
+__STATIC_INLINE void nrf_qspi_cinstr_long_transfer_start(NRF_QSPI_Type *                p_reg,
+                                                         const nrf_qspi_cinstr_conf_t * p_config)
+{
+    p_reg->CINSTRCONF = (((uint32_t)p_config->opcode    << QSPI_CINSTRCONF_OPCODE_Pos) |
+                         ((uint32_t)p_config->length    << QSPI_CINSTRCONF_LENGTH_Pos) |
+                         ((uint32_t)p_config->io2_level << QSPI_CINSTRCONF_LIO2_Pos) |
+                         ((uint32_t)p_config->io3_level << QSPI_CINSTRCONF_LIO3_Pos) |
+                         ((uint32_t)p_config->wipwait   << QSPI_CINSTRCONF_WIPWAIT_Pos) |
+                         ((uint32_t)p_config->wren      << QSPI_CINSTRCONF_WREN_Pos) |
+                         (QSPI_CINSTRCONF_LFEN_Msk));
+}
+
+__STATIC_INLINE bool nrf_qspi_cinstr_long_transfer_is_ongoing(NRF_QSPI_Type const * p_reg)
+{
+    return (bool)((p_reg->CINSTRCONF & (QSPI_CINSTRCONF_LFEN_Msk | QSPI_CINSTRCONF_LFSTOP_Msk))
+                   == QSPI_CINSTRCONF_LFEN_Msk);
+}
+
+__STATIC_INLINE void nrf_qspi_cinstr_long_transfer_continue(NRF_QSPI_Type *       p_reg,
+                                                            nrf_qspi_cinstr_len_t length,
+                                                            bool                  finalize)
+{
+    uint32_t mask = (((uint32_t)length << QSPI_CINSTRCONF_LENGTH_Pos) | (QSPI_CINSTRCONF_LFEN_Msk));
+    mask |= (finalize ? QSPI_CINSTRCONF_LFSTOP_Msk : 0);
+
+    p_reg->CINSTRCONF = mask;
 }
 
 #endif // SUPPRESS_INLINE_IMPLEMENTATION


### PR DESCRIPTION
Long Frame Mode functions will be helpful for supporting the GIGA device flash part, since the OTP (ie Security Register) read/writes require custom SPI instructions with variable length data > 9 bytes. 